### PR TITLE
Clean up frontend dependencies and lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag to build (e.g. 0.2.0)'
+        description: "Version tag to build (e.g. 0.2.0)"
         required: true
-        default: '0.2.0'
+        default: "0.2.0"
 
 permissions:
   contents: read
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -45,7 +45,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event.release.prerelease != true }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,8 @@ jobs:
       - name: Install frontend
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         run: npm run build

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -3,31 +3,33 @@ module.exports = {
   env: { browser: true, es2020: true },
   settings: {
     react: {
-      version: "detect",
+      version: 'detect',
     },
   },
   extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended-type-checked",
-    "plugin:@typescript-eslint/stylistic-type-checked",
-    "plugin:react-hooks/recommended",
-    "plugin:react/recommended",
-    "plugin:react/jsx-runtime",
-    "prettier",
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+    'plugin:react-hooks/recommended',
+    'plugin:react/recommended',
+    'plugin:react/jsx-runtime',
+    'prettier',
   ],
-  ignorePatterns: ["dist", ".eslintrc.cjs"],
-  parser: "@typescript-eslint/parser",
-  plugins: ["react-refresh"],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
   rules: {
-    "react-refresh/only-export-components": [
-      "warn",
-      { allowConstantExport: true },
-    ],
+    // TypeScript validates component props; the React rule only understands
+    // runtime PropTypes and reports false positives for typed Radix wrappers.
+    'react/prop-types': 'off',
+    // Shared hooks and style helpers are intentionally exported beside the
+    // small UI components that consume them.
+    'react-refresh/only-export-components': 'off',
   },
   parserOptions: {
-    ecmaVersion: "latest",
-    sourceType: "module",
-    project: ["./tsconfig.json", "./tsconfig.vite.json"],
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    project: ['./tsconfig.json', './tsconfig.vite.json'],
     tsconfigRootDir: __dirname,
   },
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,6 @@
         "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "@types/uuid": "^9.0.8",
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -29,10 +28,10 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.51.3",
-        "react-router-dom": "^6.22.3",
+        "react-router-dom": "^7.18.2",
         "tailwind-merge": "^2.2.2",
         "tailwindcss-animate": "^1.0.7",
-        "uuid": "^9.0.1",
+        "uuid": "^14.0.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -42,7 +41,7 @@
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
         "@typescript-eslint/parser": "^7.2.0",
-        "@vitejs/plugin-react-swc": "^3.5.0",
+        "@vitejs/plugin-react-swc": "^3.11.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
@@ -53,7 +52,7 @@
         "prettier": "3.2.5",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.2.2",
-        "vite": "^5.4.11"
+        "vite": "^6.4.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -367,9 +366,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -380,13 +379,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -397,13 +396,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -414,13 +413,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -431,13 +430,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -448,13 +447,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -465,13 +464,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -482,13 +481,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -499,13 +498,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -516,13 +515,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -533,13 +532,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -550,13 +549,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -567,13 +566,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -584,13 +583,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -601,13 +600,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -618,13 +617,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -635,13 +634,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -652,13 +651,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -669,13 +685,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -686,13 +719,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -703,13 +753,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -720,13 +770,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -737,13 +787,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -754,7 +804,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1951,15 +2001,6 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2647,12 +2688,6 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -3518,6 +3553,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3936,9 +3984,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3946,32 +3994,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -6390,35 +6441,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -6714,6 +6771,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7510,35 +7573,37 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -7547,17 +7612,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -7580,7 +7651,44 @@
         },
         "terser": {
           "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "@types/uuid": "^9.0.8",
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
@@ -31,10 +30,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.3",
-    "react-router-dom": "^6.22.3",
+    "react-router-dom": "^7.18.2",
     "tailwind-merge": "^2.2.2",
     "tailwindcss-animate": "^1.0.7",
-    "uuid": "^9.0.1",
+    "uuid": "^14.0.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -44,7 +43,7 @@
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
@@ -55,7 +54,7 @@
     "prettier": "3.2.5",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.2.2",
-    "vite": "^5.4.11"
+    "vite": "^6.4.3"
   },
   "prettier": {
     "printWidth": 80,

--- a/frontend/src/components/configurationForm/fields/discoveryUrl.tsx
+++ b/frontend/src/components/configurationForm/fields/discoveryUrl.tsx
@@ -21,10 +21,11 @@ import {
 } from '@/components/ui/select.tsx';
 import { useToast } from '@/hooks/useToast';
 import { isServerAliveRemote } from '@/services/BackendService.tsx';
+import { PlexServer } from '@/types/plex.tsx';
 
 interface Props {
   form: UseFormReturn<ConfigurationFormType>;
-  server: any;
+  server: PlexServer;
 }
 
 export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
@@ -33,10 +34,10 @@ export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
   const [testInProgress, setTestInProgress] = useState(false);
   const discoveryUrl = form.watch('discoveryUrl');
 
-  const testUrl = () => {
+  const testUrl = async () => {
     setTestInProgress(true);
-    isServerAliveRemote(discoveryUrl, server.accessToken).then((alive) => {
-      setTestInProgress(false);
+    try {
+      const alive = await isServerAliveRemote(discoveryUrl, server.accessToken);
       const ipPort = parseUrlToIpPort(discoveryUrl);
       if (alive) {
         toast({
@@ -55,7 +56,9 @@ export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
           duration: 30 * 1000,
         });
       }
-    });
+    } finally {
+      setTestInProgress(false);
+    }
   };
 
   return (
@@ -76,19 +79,19 @@ export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
                   <SelectValue placeholder="Select a discovery url" />
                 </SelectTrigger>
               </FormControl>
-              {server.connections.filter((conn: any) => !conn.local).length >
-                0 && (
+              {server.connections.filter((connection) => !connection.local)
+                .length > 0 && (
                 <SelectContent>
                   {server.connections
-                    .filter((conn: any) => !conn.local)
-                    .map((conn: any, index: number) => (
-                      <SelectItem key={index} value={conn.uri}>
-                        {conn.relay && (
+                    .filter((connection) => !connection.local)
+                    .map((connection) => (
+                      <SelectItem key={connection.uri} value={connection.uri}>
+                        {connection.relay && (
                           <Badge className="mr-1.5" variant="secondary">
                             relay
                           </Badge>
                         )}
-                        {`${conn.address}:${conn.port}`}
+                        {`${connection.address}:${connection.port}`}
                       </SelectItem>
                     ))}
                 </SelectContent>
@@ -98,7 +101,9 @@ export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
               className="ml-2.5 h-10 w-16"
               type="button"
               disabled={testInProgress || !discoveryUrl}
-              onClick={testUrl}
+              onClick={() => {
+                void testUrl();
+              }}
             >
               {testInProgress ? (
                 <div className="w-5 h-5 rounded-full animate-spin border-t-2" />

--- a/frontend/src/components/configurationForm/fields/includeTranscodeDown.tsx
+++ b/frontend/src/components/configurationForm/fields/includeTranscodeDown.tsx
@@ -71,7 +71,7 @@ export const IncludeTranscodeDownFields: FC<Props> = ({ form }) => {
                             checked={field.value?.includes(item)}
                             onCheckedChange={(checked) => {
                               return checked
-                                ? field.onChange([...(field.value || []), item])
+                                ? field.onChange([...(field.value ?? []), item])
                                 : field.onChange(
                                     field.value?.filter(
                                       (value) => value !== item,

--- a/frontend/src/components/configurationForm/fields/sections.tsx
+++ b/frontend/src/components/configurationForm/fields/sections.tsx
@@ -10,10 +10,11 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form.tsx';
+import { PlexSection } from '@/types/plex.tsx';
 
 interface Props {
   form: UseFormReturn<ConfigurationFormType>;
-  sections: any[];
+  sections: PlexSection[];
 }
 
 export const SectionsField: FC<Props> = ({ form, sections }) => {
@@ -30,7 +31,7 @@ export const SectionsField: FC<Props> = ({ form, sections }) => {
             </FormDescription>
           </div>
           {sections.length > 0 ? (
-            sections.map((item: any) => (
+            sections.map((item) => (
               <FormField
                 key={item.key}
                 control={form.control}
@@ -47,7 +48,7 @@ export const SectionsField: FC<Props> = ({ form, sections }) => {
                           onCheckedChange={(checked) => {
                             return checked
                               ? field.onChange([
-                                  ...(field.value || []),
+                                  ...(field.value ?? []),
                                   {
                                     key: item.key,
                                     title: item.title,

--- a/frontend/src/components/configurationForm/fields/serverName.tsx
+++ b/frontend/src/components/configurationForm/fields/serverName.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select.tsx';
+import { PlexServer } from '@/types/plex.tsx';
 
 interface Props {
   form: UseFormReturn<ConfigurationFormType>;

--- a/frontend/src/components/configurationForm/fields/streamingUrl.tsx
+++ b/frontend/src/components/configurationForm/fields/streamingUrl.tsx
@@ -21,10 +21,11 @@ import {
 } from '@/components/ui/select.tsx';
 import { useToast } from '@/hooks/useToast';
 import { isServerAliveLocal } from '@/services/PMSService.tsx';
+import { PlexServer } from '@/types/plex.tsx';
 
 interface Props {
   form: UseFormReturn<ConfigurationFormType>;
-  server: any;
+  server: PlexServer;
 }
 
 export const StreamingUrlField: FC<Props> = ({ form, server }) => {
@@ -33,10 +34,10 @@ export const StreamingUrlField: FC<Props> = ({ form, server }) => {
   const [testInProgress, setTestInProgress] = useState(false);
   const streamingUrl = form.watch('streamingUrl');
 
-  const testUrl = () => {
+  const testUrl = async () => {
     setTestInProgress(true);
-    isServerAliveLocal(streamingUrl, server.accessToken).then((alive) => {
-      setTestInProgress(false);
+    try {
+      const alive = await isServerAliveLocal(streamingUrl, server.accessToken);
       const ipPort = parseUrlToIpPort(streamingUrl);
       if (alive) {
         toast({
@@ -57,7 +58,9 @@ export const StreamingUrlField: FC<Props> = ({ form, server }) => {
           duration: 30 * 1000,
         });
       }
-    });
+    } finally {
+      setTestInProgress(false);
+    }
   };
 
   return (
@@ -80,19 +83,19 @@ export const StreamingUrlField: FC<Props> = ({ form, server }) => {
               </FormControl>
               {server.connections.length > 0 && (
                 <SelectContent>
-                  {server.connections.map((conn: any, index: number) => (
-                    <SelectItem key={index} value={conn.uri}>
-                      {conn.local && (
+                  {server.connections.map((connection) => (
+                    <SelectItem key={connection.uri} value={connection.uri}>
+                      {connection.local && (
                         <Badge className="mr-1.5" variant="secondary">
                           local
                         </Badge>
                       )}
-                      {conn.relay && (
+                      {connection.relay && (
                         <Badge className="mr-1.5" variant="secondary">
                           relay
                         </Badge>
                       )}
-                      {`${conn.address}:${conn.port}`}
+                      {`${connection.address}:${connection.port}`}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -102,7 +105,9 @@ export const StreamingUrlField: FC<Props> = ({ form, server }) => {
               className="ml-2.5 h-10 w-16"
               type="button"
               disabled={testInProgress || !streamingUrl}
-              onClick={testUrl}
+              onClick={() => {
+                void testUrl();
+              }}
             >
               {testInProgress ? (
                 <div className="w-5 h-5 rounded-full animate-spin border-t-2" />

--- a/frontend/src/components/configurationForm/index.tsx
+++ b/frontend/src/components/configurationForm/index.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { encode as base64_encode } from 'js-base64';
-import { useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { v4 as uuidv4 } from 'uuid';
 import {
   DiscoveryUrlField,
@@ -22,18 +22,21 @@ import { Button } from '@/components/ui/button.tsx';
 import { Form } from '@/components/ui/form';
 import usePMSSections from '@/hooks/usePMSSections.tsx';
 import { createSession, getPublicConfig } from '@/services/BackendService.tsx';
+import { PlexServer } from '@/types/plex.tsx';
 
 interface Props {
   servers: PlexServer[];
 }
 
 const ConfigurationForm: FC<Props> = ({ servers }) => {
-  const [baseUrl, setBaseUrl] = useState<string>('');
+  const [baseUrl, setBaseUrl] = useState<string | null>(null);
 
   useEffect(() => {
     // Fetch once at mount. If the backend doesn't respond or BASE_URL isn't set,
-    // baseUrl stays empty and we fall back to window.location.origin below.
-    getPublicConfig().then(({ baseUrl }) => setBaseUrl(baseUrl));
+    // baseUrl stays null and we fall back to window.location.origin below.
+    void getPublicConfig().then(({ baseUrl }) => {
+      setBaseUrl(baseUrl.length > 0 ? baseUrl : null);
+    });
   }, []);
 
   const form = useForm<ConfigurationFormType>({
@@ -48,39 +51,54 @@ const ConfigurationForm: FC<Props> = ({ servers }) => {
   });
 
   const serverName = form.watch('serverName');
-  const server = servers.find((s) => s.name == serverName);
+  const server = servers.find((candidate) => candidate.name === serverName);
 
   const discoveryUrl = form.watch('discoveryUrl');
-  const sections = usePMSSections(discoveryUrl, server?.accessToken || null);
+  const sections = usePMSSections(discoveryUrl, server?.accessToken ?? null);
 
-  async function onSubmit(configuration: any, event: any) {
+  const onSubmit: SubmitHandler<ConfigurationFormType> = async (
+    configuration,
+    event,
+  ) => {
+    if (!server) {
+      return;
+    }
+
     // Read which button submitted before any await (the native event's
     // submitter must be captured synchronously).
-    const action = event.nativeEvent.submitter.name;
+    const nativeEvent = event?.nativeEvent;
+    const submitter =
+      nativeEvent instanceof SubmitEvent ? nativeEvent.submitter : null;
+    const action = submitter instanceof HTMLButtonElement ? submitter.name : '';
 
-    configuration.version = __APP_VERSION__;
-    configuration.accessToken = server?.accessToken;
-    configuration.sections = configuration.sections.filter((item: any) =>
-      sections.find((s) => s.key === item.key),
-    );
+    const normalizedConfiguration = {
+      ...configuration,
+      version: __APP_VERSION__,
+      accessToken: server.accessToken,
+      sections: configuration.sections.filter((item) =>
+        sections.some((section) => section.key === item.key),
+      ),
+    };
 
     // Prefer operator-configured BASE_URL when set (for reverse-proxy deployments
     // where window.location.origin may not match the public-facing URL).
     // Falls back to window.location.origin for default localhost deployments.
-    const origin = baseUrl || window.location.origin;
+    const origin = baseUrl ?? window.location.origin;
 
     // Prefer a server-side session so the Plex token never appears in the URL.
     // Fall back to the legacy base64 install URL if sessions are disabled (404)
     // or the request fails.
     const sessionId = await createSession(
-      configuration,
-      configuration.serverName,
+      normalizedConfiguration,
+      normalizedConfiguration.serverName,
     );
     let addonUrl: string;
     if (sessionId) {
       addonUrl = `${origin}/${sessionId}/manifest.json`;
     } else {
-      const encodedConfiguration = base64_encode(JSON.stringify(configuration));
+      const encodedConfiguration = base64_encode(
+        JSON.stringify(normalizedConfiguration),
+      );
       addonUrl = `${origin}/${uuidv4()}/${encodedConfiguration}/manifest.json`;
     }
 
@@ -93,12 +111,14 @@ const ConfigurationForm: FC<Props> = ({ servers }) => {
     } else {
       window.location.href = addonUrl.replace(/https?:\/\//, 'stremio://');
     }
-  }
+  };
 
   return (
     <Form {...form}>
       <form
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={(event) => {
+          void form.handleSubmit(onSubmit)(event);
+        }}
         className="space-y-2 p-2 rounded-lg border"
       >
         <ServerNameField form={form} servers={servers} />

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -3,6 +3,7 @@ import { Icons } from '@/components/icons.tsx';
 import { ThemeToggle } from '@/components/themeToggle.tsx';
 import { Avatar, AvatarImage } from '@/components/ui/avatar.tsx';
 import { Button } from '@/components/ui/button.tsx';
+import { PlexUser } from '@/types/plex.tsx';
 
 interface Props {
   plexUser: PlexUser | null | undefined;

--- a/frontend/src/components/login.tsx
+++ b/frontend/src/components/login.tsx
@@ -30,7 +30,12 @@ const Login = () => {
         your Plex media directly within Stremio.
       </p>
       <div className="mt-6">
-        <Button onClick={handleLogin} className="w-full">
+        <Button
+          onClick={() => {
+            void handleLogin();
+          }}
+          className="w-full"
+        >
           Login
         </Button>
       </div>

--- a/frontend/src/components/protectedForm.tsx
+++ b/frontend/src/components/protectedForm.tsx
@@ -3,6 +3,7 @@ import ConfigurationForm from '@/components/configurationForm';
 import Loading from '@/components/loading.tsx';
 import Login from '@/components/login.tsx';
 import usePlexServers from '@/hooks/usePlexServers.tsx';
+import { PlexUser } from '@/types/plex.tsx';
 
 interface Props {
   plexToken: string | null;

--- a/frontend/src/components/ui/form.tsx
+++ b/frontend/src/components/ui/form.tsx
@@ -14,12 +14,12 @@ import { cn } from '@/lib/utils';
 
 const Form = FormProvider;
 
-type FormFieldContextValue<
+interface FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
+> {
   name: TName;
-};
+}
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
   {} as FormFieldContextValue,
@@ -61,9 +61,9 @@ const useFormField = () => {
   };
 };
 
-type FormItemContextValue = {
+interface FormItemContextValue {
   id: string;
-};
+}
 
 const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue,

--- a/frontend/src/hooks/usePMSSections.tsx
+++ b/frontend/src/hooks/usePMSSections.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { PlexToken } from '@/hooks/usePlexToken.tsx';
 import { getSections } from '@/services/PMSService.tsx';
+import { PlexSection } from '@/types/plex.tsx';
 
 const usePMSSections = (serverUrl: string, plexToken: PlexToken) => {
-  const [sections, setSections] = useState<any[]>([]);
+  const [sections, setSections] = useState<PlexSection[]>([]);
 
   useEffect(() => {
     setSections([]);

--- a/frontend/src/hooks/usePlexServers.tsx
+++ b/frontend/src/hooks/usePlexServers.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import useClientIdentifier from '@/hooks/useClientIdentifier.tsx';
 import { PlexToken } from '@/hooks/usePlexToken.tsx';
 import { getPlexServers } from '@/services/PlexService.tsx';
+import { PlexServer } from '@/types/plex.tsx';
 
 const usePlexServers = (plexToken: PlexToken | null) => {
   const [servers, setServers] = useState<PlexServer[]>([]);

--- a/frontend/src/hooks/usePlexToken.tsx
+++ b/frontend/src/hooks/usePlexToken.tsx
@@ -2,9 +2,7 @@ import { useEffect, useState } from 'react';
 
 export type PlexToken = string | null;
 
-export interface SetPlexToken {
-  (token: PlexToken): void;
-}
+export type SetPlexToken = (token: PlexToken) => void;
 
 const usePlexToken = (): [PlexToken, SetPlexToken] => {
   const [token, setToken] = useState<PlexToken>(() =>

--- a/frontend/src/hooks/usePlexUser.tsx
+++ b/frontend/src/hooks/usePlexUser.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import useClientIdentifier from '@/hooks/useClientIdentifier.tsx';
 import { PlexToken } from '@/hooks/usePlexToken.tsx';
 import { getPlexUser } from '@/services/PlexService.tsx';
+import { PlexUser } from '@/types/plex.tsx';
 
 const usePlexUser = (plexToken: PlexToken) => {
   const [user, setUser] = useState<undefined | null | PlexUser>();

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -125,7 +125,7 @@ export const reducer = (state: State, action: Action): State => {
   }
 };
 
-const listeners: Array<(state: State) => void> = [];
+const listeners: ((state: State) => void)[] = [];
 
 let memoryState: State = { toasts: [] };
 

--- a/frontend/src/pages/AuthRedirectPage.tsx
+++ b/frontend/src/pages/AuthRedirectPage.tsx
@@ -17,19 +17,28 @@ const AuthRedirectPage: FC<Props> = ({ setPlexToken }) => {
   useEffect(() => {
     if (!clientIdentifier) return;
 
-    const { id, code, redirect } = Object.fromEntries(searchParams.entries());
+    const id = searchParams.get('id');
+    const code = searchParams.get('code');
+    const redirect = searchParams.get('redirect');
+    const safeRedirect =
+      redirect?.startsWith('/') &&
+      !redirect.startsWith('//') &&
+      !redirect.includes('\\')
+        ? redirect
+        : '/';
 
     const setAuthToken = async (): Promise<void> => {
-      const authToken = await getAuthToken(
-        { id: id, code: code },
-        clientIdentifier,
-      );
+      if (!id || !code) {
+        void navigate('/', { replace: true });
+        return;
+      }
+      const authToken = await getAuthToken({ id, code }, clientIdentifier);
       setPlexToken(authToken);
+      void navigate(safeRedirect, { replace: true });
     };
 
     void setAuthToken();
-    navigate(redirect);
-  }, [searchParams, clientIdentifier, navigate]);
+  }, [searchParams, clientIdentifier, navigate, setPlexToken]);
 
   return <Loading />;
 };

--- a/frontend/src/services/BackendService.tsx
+++ b/frontend/src/services/BackendService.tsx
@@ -1,8 +1,20 @@
 import axios from 'axios';
 
+interface TestConnectionResponse {
+  success: boolean;
+}
+
+interface PublicConfigResponse {
+  base_url?: string;
+}
+
+interface SessionResponse {
+  session_id?: string;
+}
+
 export const isServerAliveRemote = async (serverUrl: string, token: string) => {
   try {
-    const response = await axios.get(
+    const response = await axios.get<TestConnectionResponse>(
       `${window.location.origin}/api/v1/test-connection`,
       {
         timeout: 25000,
@@ -12,7 +24,7 @@ export const isServerAliveRemote = async (serverUrl: string, token: string) => {
         },
       },
     );
-    return response.data?.success;
+    return response.data.success;
   } catch (error) {
     console.error('Error while ping PMS remote:', error);
     return false;
@@ -21,11 +33,11 @@ export const isServerAliveRemote = async (serverUrl: string, token: string) => {
 
 export const getPublicConfig = async (): Promise<{ baseUrl: string }> => {
   try {
-    const response = await axios.get(
+    const response = await axios.get<PublicConfigResponse>(
       `${window.location.origin}/api/v1/public-config`,
       { timeout: 5000 },
     );
-    return { baseUrl: response.data?.base_url || '' };
+    return { baseUrl: response.data.base_url ?? '' };
   } catch (error) {
     console.error('Error fetching public config:', error);
     return { baseUrl: '' };
@@ -40,8 +52,10 @@ export const createSession = async (
     const url =
       `${window.location.origin}/api/v1/sessions` +
       (label ? `?label=${encodeURIComponent(label)}` : '');
-    const response = await axios.post(url, configuration, { timeout: 15000 });
-    return response.data?.session_id || null;
+    const response = await axios.post<SessionResponse>(url, configuration, {
+      timeout: 15000,
+    });
+    return response.data.session_id ?? null;
   } catch (error) {
     // Sessions disabled (404) or unreachable: caller falls back to base64.
     console.error('Error creating session:', error);

--- a/frontend/src/services/PMSService.tsx
+++ b/frontend/src/services/PMSService.tsx
@@ -1,4 +1,11 @@
 import axios from 'axios';
+import { PlexSection } from '@/types/plex.tsx';
+
+interface SectionsResponse {
+  MediaContainer?: {
+    Directory?: PlexSection[];
+  };
+}
 
 export const isServerAliveLocal = async (serverUrl: string, token: string) => {
   try {
@@ -18,23 +25,26 @@ export const isServerAliveLocal = async (serverUrl: string, token: string) => {
 export const getSections = async (
   serverUrl: string,
   token: string,
-): Promise<any[]> => {
+): Promise<PlexSection[]> => {
   try {
-    const response = await axios.get(`${serverUrl}/library/sections`, {
-      timeout: 25000,
-      params: {
-        'X-Plex-Token': token,
+    const response = await axios.get<SectionsResponse>(
+      `${serverUrl}/library/sections`,
+      {
+        timeout: 25000,
+        params: {
+          'X-Plex-Token': token,
+        },
       },
-    });
+    );
 
-    const sections = response.data?.MediaContainer?.Directory;
+    const sections = response.data.MediaContainer?.Directory;
 
     if (!Array.isArray(sections)) {
       throw new Error('Invalid response from server');
     }
 
-    return sections.filter((section: any) =>
-      ['show', 'movie'].includes(section?.type),
+    return sections.filter((section) =>
+      ['show', 'movie'].includes(section.type),
     );
   } catch (error) {
     console.error('Error fetching Plex servers:', error);

--- a/frontend/src/services/PlexService.tsx
+++ b/frontend/src/services/PlexService.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { AuthPin, PlexServer, PlexUser } from '@/types/plex.tsx';
 
 const PLEX_PRODUCT_NAME = 'Plexio';
 const PLEX_API_URL = 'https://plex.tv/api/v2';
@@ -7,7 +8,7 @@ export const createAuthPin = async (
   clientIdentifier: string,
 ): Promise<AuthPin> => {
   try {
-    const response = await axios.post('/api/v1/plex-pin', null, {
+    const response = await axios.post<AuthPin>('/api/v1/plex-pin', null, {
       headers: {
         'X-Plex-Client-Identifier': clientIdentifier,
       },
@@ -25,14 +26,17 @@ export const getAuthToken = async (
   clientIdentifier: string,
 ): Promise<string> => {
   try {
-    const response = await axios.get(`/api/v1/plex-token/${authPin.id}`, {
-      params: {
-        code: authPin.code,
+    const response = await axios.get<{ authToken: string }>(
+      `/api/v1/plex-token/${authPin.id}`,
+      {
+        params: {
+          code: authPin.code,
+        },
+        headers: {
+          'X-Plex-Client-Identifier': clientIdentifier,
+        },
       },
-      headers: {
-        'X-Plex-Client-Identifier': clientIdentifier,
-      },
-    });
+    );
     return response.data.authToken;
   } catch (error) {
     console.error('Error auth token:', error);
@@ -45,7 +49,7 @@ export const getPlexUser = async (
   clientIdentifier: string,
 ): Promise<PlexUser | null> => {
   try {
-    const response = await axios.get(`${PLEX_API_URL}/user`, {
+    const response = await axios.get<PlexUser>(`${PLEX_API_URL}/user`, {
       params: {
         'X-Plex-Product': PLEX_PRODUCT_NAME,
         'X-Plex-Client-Identifier': clientIdentifier,
@@ -69,7 +73,7 @@ export const getPlexServers = async (
   clientIdentifier: string,
 ): Promise<PlexServer[]> => {
   try {
-    const response = await axios.get('/api/v1/plex-resources', {
+    const response = await axios.get<PlexServer[]>('/api/v1/plex-resources', {
       params: {
         includeHttps: 1,
         includeRelay: 1,
@@ -85,8 +89,8 @@ export const getPlexServers = async (
     }
 
     return response.data.filter(
-      (server: any) =>
-        server.provides.includes('server') && 'accessToken' in server,
+      (server) =>
+        server.provides.includes('server') && Boolean(server.accessToken),
     );
   } catch (error) {
     console.error('Error fetching Plex servers:', error);

--- a/frontend/src/types/plex.tsx
+++ b/frontend/src/types/plex.tsx
@@ -1,20 +1,35 @@
-interface AuthPin {
+export interface AuthPin {
   id: string;
   code: string;
 }
 
-interface PlexUser {
+export interface PlexUser {
   username: string;
   thumb: string;
 }
 
-interface PlexServer {
+export interface PlexConnection {
+  uri: string;
+  address: string;
+  port: number;
+  local: boolean;
+  relay: boolean;
+}
+
+export interface PlexServer {
   name: string;
   sourceTitle: string | null;
   publicAddress: string;
   accessToken: string;
+  provides: string;
   relay: boolean;
   owned: boolean;
   httpsRequired: boolean;
-  connections: any[];
+  connections: PlexConnection[];
+}
+
+export interface PlexSection {
+  key: string;
+  title: string;
+  type: 'movie' | 'show';
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,15 +1,24 @@
-import path from "path";
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve(__dirname, './src'),
     },
   },
   define: {
-    "__APP_VERSION__": JSON.stringify(process.env.npm_package_version)
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
   },
-})
+});


### PR DESCRIPTION
## Summary
- upgrade React Router, UUID, Vite, and the React SWC plugin to patched versions
- remove obsolete UUID type stubs and replace unsafe frontend `any` usage with typed Plex/API responses
- harden the auth redirect flow and make async event handling explicit
- split the React vendor bundle, update Docker build actions, and add frontend linting to CI

## Validation
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `ruff check .`
- `python -m unittest discover -s tests -v` (17 tests)
- actionlint v1.7.12
- Prettier check on all changed files
