### PR TITLE
Add Direct Play controls and connection fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-See the pull requests linked from the next GitHub release.
+- Added a Direct Play switch so shared-server users can choose Plex transcodes
+  when original-file playback is unavailable.
+- Added optional, labelled Direct Play choices for all authorized local, remote,
+  and Plex Relay server connections.
+- Playback-reporting streams now retry alternate connections after network
+  errors and HTTP 502/503/504 responses.
 
 ## v0.8.2
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Plexio is independent and is not affiliated with Plex or Stremio.
 
 ## Highlights
 
-- Direct Play and optional Plex transcoding streams.
+- Configurable Direct Play and optional Plex transcoding streams.
 - Local, remote, shared-server, and Plex Relay connections.
+- Clearly labelled alternate-connection streams, with automatic proxy fallback.
 - Continue Watching, Recently Added, searchable library, and sort catalogs.
 - IMDb IDs when available, with Plex-native IDs for personal or unmatched media.
 - Stremio stream metadata including filename and file size.
@@ -81,6 +82,18 @@ If you enable “Report playback to Plex”, Direct Play streams pass through
 Plexio. The public URL must then be reachable by every Stremio device and your
 proxy must permit byte-range requests and long-running responses.
 
+## Playback controls
+
+Direct Play is enabled by default. You can turn it off when a shared server
+rejects original-file playback and offer only Plex transcodes instead. Enable
+“Include alternate Plex connections” to expose the selected server's other
+local, remote, and Relay URLs as labelled Direct Play choices.
+
+When playback reporting is also enabled, Plexio presents one Direct Play choice
+and automatically retries those authorized connections after connection errors
+or HTTP 502/503/504 responses. It does not bypass Plex account or remote-play
+permissions.
+
 ## Shared servers and Plex Pass
 
 For media matching on a server shared with you, set `PLEX_MATCHING_TOKEN` to an
@@ -118,7 +131,6 @@ Use [GitHub Issues](https://github.com/natedogg058/plexio/issues) for support an
 feature requests. Include sanitized logs and diagnostics, but never a Plex token
 or a complete media URL.
 
-Current roadmap themes are connection fallback/selection, Direct Play controls,
-richer stream metadata, Plex collection catalogs, and deployment smoke coverage.
+Current roadmap themes are richer stream metadata and Plex collection catalogs.
 
 See [CHANGELOG.md](CHANGELOG.md) for maintained-fork release history.

--- a/frontend/src/components/configurationForm/fields/includeConnectionFallbacks.tsx
+++ b/frontend/src/components/configurationForm/fields/includeConnectionFallbacks.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { ConfigurationFormType } from '@/components/configurationForm/formSchema.tsx';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form.tsx';
+import { Switch } from '@/components/ui/switch.tsx';
+
+interface Props {
+  form: UseFormReturn<ConfigurationFormType>;
+}
+
+export const IncludeConnectionFallbacksField: FC<Props> = ({ form }) => {
+  return (
+    <FormField
+      control={form.control}
+      name="includeConnectionFallbacks"
+      render={({ field }) => (
+        <FormItem className="items-center justify-between flex flex-row rounded-lg border p-2">
+          <div className="space-y-0.5">
+            <FormLabel className="text-base">
+              Include alternate Plex connections
+            </FormLabel>
+            <FormDescription>
+              Offer the server&apos;s other local, remote, and Relay connections
+              as clearly labelled Direct Play choices. Playback reporting also
+              retries these connections automatically after gateway failures.
+            </FormDescription>
+          </div>
+          <FormControl>
+            <Switch checked={field.value} onCheckedChange={field.onChange} />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/frontend/src/components/configurationForm/fields/includeDirectPlay.tsx
+++ b/frontend/src/components/configurationForm/fields/includeDirectPlay.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { ConfigurationFormType } from '@/components/configurationForm/formSchema.tsx';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form.tsx';
+import { Switch } from '@/components/ui/switch.tsx';
+
+interface Props {
+  form: UseFormReturn<ConfigurationFormType>;
+}
+
+export const IncludeDirectPlayField: FC<Props> = ({ form }) => {
+  return (
+    <FormField
+      control={form.control}
+      name="includeDirectPlay"
+      render={({ field }) => (
+        <FormItem className="items-center justify-between flex flex-row rounded-lg border p-2">
+          <div className="space-y-0.5">
+            <FormLabel className="text-base">Include Direct Play</FormLabel>
+            <FormDescription>
+              Offer original-file streams. Turn this off when a shared server
+              returns 503 for Direct Play and use Plex transcodes instead.
+            </FormDescription>
+          </div>
+          <FormControl>
+            <Switch checked={field.value} onCheckedChange={field.onChange} />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/frontend/src/components/configurationForm/fields/index.tsx
+++ b/frontend/src/components/configurationForm/fields/index.tsx
@@ -2,6 +2,8 @@ export { ServerNameField } from './serverName.tsx';
 export { DiscoveryUrlField } from './discoveryUrl.tsx';
 export { StreamingUrlField } from './streamingUrl.tsx';
 export { SectionsField } from './sections.tsx';
+export { IncludeDirectPlayField } from './includeDirectPlay.tsx';
+export { IncludeConnectionFallbacksField } from './includeConnectionFallbacks.tsx';
 export { IncludeTranscodeOriginalField } from './includeTranscodeOriginal.tsx';
 export { IncludeTranscodeDownFields } from './includeTranscodeDown.tsx';
 export { IncludePlexTvField } from './includePlexTv.tsx';

--- a/frontend/src/components/configurationForm/formSchema.tsx
+++ b/frontend/src/components/configurationForm/formSchema.tsx
@@ -12,6 +12,8 @@ export const formSchema = z.object({
         type: z.string(),
       }),
     ),
+  includeDirectPlay: z.boolean(),
+  includeConnectionFallbacks: z.boolean(),
   includeTranscodeOriginal: z.boolean(),
   includeTranscodeDown: z.boolean(),
   transcodeDownQualities: z.array(z.string()).optional(),

--- a/frontend/src/components/configurationForm/index.tsx
+++ b/frontend/src/components/configurationForm/index.tsx
@@ -6,6 +6,8 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   DiscoveryUrlField,
   IncludeTranscodeOriginalField,
+  IncludeDirectPlayField,
+  IncludeConnectionFallbacksField,
   SectionsField,
   ServerNameField,
   StreamingUrlField,
@@ -50,6 +52,8 @@ const ConfigurationForm: FC<Props> = ({
   const form = useForm<ConfigurationFormType>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      includeDirectPlay: true,
+      includeConnectionFallbacks: false,
       includeTranscodeOriginal: false,
       includeTranscodeDown: false,
       includePlexTv: false,
@@ -78,11 +82,33 @@ const ConfigurationForm: FC<Props> = ({
     const submitter =
       nativeEvent instanceof SubmitEvent ? nativeEvent.submitter : null;
     const action = submitter instanceof HTMLButtonElement ? submitter.name : '';
+    const includeConnectionFallbacks =
+      configuration.includeDirectPlay &&
+      configuration.includeConnectionFallbacks;
 
     const normalizedConfiguration = {
       ...configuration,
+      includeConnectionFallbacks,
       version: __APP_VERSION__,
       accessToken: server.accessToken,
+      streamingConnectionKind: (() => {
+        const selected = server.connections.find(
+          (connection) => connection.uri === configuration.streamingUrl,
+        );
+        return selected?.relay ? 'relay' : selected?.local ? 'local' : 'remote';
+      })(),
+      streamingConnections: includeConnectionFallbacks
+        ? server.connections
+            .filter((connection) => connection.uri !== configuration.streamingUrl)
+            .map((connection) => ({
+              url: connection.uri,
+              kind: connection.relay
+                ? 'relay'
+                : connection.local
+                  ? 'local'
+                  : 'remote',
+            }))
+        : [],
       sections: configuration.sections.filter((item) =>
         sections.some((section) => section.key === item.key),
       ),
@@ -150,6 +176,10 @@ const ConfigurationForm: FC<Props> = ({
         )}
         {discoveryUrl && (
           <SectionsField form={form} sections={sections}></SectionsField>
+        )}
+        <IncludeDirectPlayField form={form} />
+        {form.watch('includeDirectPlay') && (
+          <IncludeConnectionFallbacksField form={form} />
         )}
         <IncludeTranscodeOriginalField form={form} />
         <IncludeTranscodeDownFields form={form} />

--- a/plexio/models/addon.py
+++ b/plexio/models/addon.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from yarl import URL
 
@@ -23,6 +25,29 @@ def validate_plex_url(value: str | URL) -> URL:
     return url
 
 
+class PlexConnectionKind(str, Enum):
+    local = 'local'
+    remote = 'remote'
+    relay = 'relay'
+
+
+class PlexStreamingConnection(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        arbitrary_types_allowed=True,
+        extra='forbid',
+        populate_by_name=True,
+    )
+
+    url: URL
+    kind: PlexConnectionKind = PlexConnectionKind.remote
+
+    @field_validator('url', mode='before')
+    @classmethod
+    def validate_url(cls, value):
+        return validate_plex_url(value)
+
+
 class AddonConfiguration(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
@@ -34,9 +59,16 @@ class AddonConfiguration(BaseModel):
     access_token: str = Field(min_length=1, max_length=4096)
     discovery_url: URL
     streaming_url: URL
+    streaming_connection_kind: PlexConnectionKind = PlexConnectionKind.remote
+    streaming_connections: list[PlexStreamingConnection] = Field(
+        default_factory=list,
+        max_length=20,
+    )
     server_name: str = Field(min_length=1, max_length=255)
     version: str = Field(default='0.0.1', min_length=1, max_length=64)
     sections: list[PlexLibrarySection] = Field(default_factory=list, max_length=100)
+    include_direct_play: bool = True
+    include_connection_fallbacks: bool = False
     include_transcode_original: bool = False
     include_transcode_down: bool = False
     transcode_down_qualities: list[Resolution] = Field(default_factory=list)
@@ -52,4 +84,28 @@ class AddonConfiguration(BaseModel):
         config = self.model_dump(by_alias=True)
         config['discoveryUrl'] = str(self.discovery_url).rstrip('/')
         config['streamingUrl'] = str(self.streaming_url).rstrip('/')
+        config['streamingConnections'] = [
+            {
+                'url': str(connection.url).rstrip('/'),
+                'kind': connection.kind.value,
+            }
+            for connection in self.streaming_connections
+        ]
         return config
+
+    @property
+    def direct_play_connections(self) -> list[tuple[URL, PlexConnectionKind]]:
+        connections = [(self.streaming_url, self.streaming_connection_kind)]
+        if self.include_connection_fallbacks:
+            connections.extend(
+                (connection.url, connection.kind)
+                for connection in self.streaming_connections
+            )
+        deduplicated = []
+        seen = set()
+        for url, kind in connections:
+            key = str(url).rstrip('/')
+            if key not in seen:
+                seen.add(key)
+                deduplicated.append((URL(key), kind))
+        return deduplicated

--- a/plexio/models/plex.py
+++ b/plexio/models/plex.py
@@ -49,6 +49,17 @@ RESOLUTION_QUALITY_PARAMS = {
 }
 
 
+def _external_subtitles(subtitle_streams, base_url, access_token):
+    return [
+        {
+            'id': str(stream['id']),
+            'lang': stream['displayTitle'],
+            'url': str(base_url / stream['key'][1:] % {'X-Plex-Token': access_token}),
+        }
+        for stream in subtitle_streams
+    ]
+
+
 class PlexMediaType(str, Enum):
     show = 'show'
     movie = 'movie'
@@ -193,7 +204,7 @@ class PlexMediaMeta(BaseModel):
 
             audio_languages = set()
             subtitles_languages = set()
-            external_subtitles = []
+            subtitle_streams = []
             for part_stream in media['Part'][0].get('Stream', []):
                 if part_stream['streamType'] == 2:
                     audio_languages.add(
@@ -204,62 +215,81 @@ class PlexMediaMeta(BaseModel):
                         get_flag_emoji(part_stream.get('languageTag', 'Unknown')),
                     )
                     if 'key' in part_stream:
-                        external_subtitles.append(
-                            {
-                                'id': str(part_stream['id']),
-                                'lang': part_stream['displayTitle'],
-                                'url': str(
-                                    configuration.streaming_url
-                                    / part_stream['key'][1:]
-                                    % {
-                                        'X-Plex-Token': configuration.access_token,
-                                    }
-                                ),
-                            }
-                        )
+                        subtitle_streams.append(part_stream)
 
             description_template = '{filename}\n{quality}\n{languages}'
             languages = '/'.join(sorted(audio_languages))
             if subtitles_languages:
                 languages += f' ({"/".join(sorted(subtitles_languages))})'
 
-            quality_description = f'Direct Play {media.get("videoResolution", "")}'
-            if play_prefix:
-                rk = self.key.rsplit('/', 1)[-1]
-                pk = (
-                    base64.urlsafe_b64encode(media['Part'][0]['key'].encode())
-                    .rstrip(b'=')
-                    .decode()
+            if getattr(configuration, 'include_direct_play', True):
+                connections = getattr(
+                    configuration,
+                    'direct_play_connections',
+                    [(configuration.streaming_url, None)],
                 )
-                direct_play_url = (
-                    f'{play_prefix}/{rk}/'
-                    f'{self.duration or media.get("duration") or 0}/{pk}'
-                )
-            else:
-                direct_play_url = str(
-                    configuration.streaming_url
-                    / media['Part'][0]['key'][1:]
-                    % {
-                        'X-Plex-Token': configuration.access_token,
-                    },
-                )
-            streams.append(
-                StremioStream(
-                    name=name,
-                    description=description_template.format(
-                        filename=filename,
-                        quality=quality_description,
-                        languages=languages,
-                    ),
-                    url=direct_play_url,
-                    subtitles=external_subtitles,
-                    behaviorHints={
-                        'bingeGroup': quality_description,
-                        'filename': filename,
-                        'videoSize': video_size,
-                    },
-                ),
-            )
+                for connection_index, (stream_base, connection_kind) in enumerate(
+                    connections
+                ):
+                    kind_label = getattr(
+                        connection_kind,
+                        'value',
+                        'remote',
+                    ).capitalize()
+                    if play_prefix:
+                        if connection_index > 0:
+                            break
+                        rk = self.key.rsplit('/', 1)[-1]
+                        pk = (
+                            base64.urlsafe_b64encode(media['Part'][0]['key'].encode())
+                            .rstrip(b'=')
+                            .decode()
+                        )
+                        direct_play_url = (
+                            f'{play_prefix}/{rk}/'
+                            f'{self.duration or media.get("duration") or 0}/{pk}'
+                        )
+                        connection_label = (
+                            'Automatic connection fallback'
+                            if len(connections) > 1
+                            else kind_label
+                        )
+                    else:
+                        direct_play_url = str(
+                            stream_base
+                            / media['Part'][0]['key'][1:]
+                            % {'X-Plex-Token': configuration.access_token},
+                        )
+                        connection_label = (
+                            f'Primary {kind_label}'
+                            if connection_index == 0
+                            else f'Alternate {kind_label}'
+                        )
+                    quality_description = (
+                        f'Direct Play {media.get("videoResolution", "")} '
+                        f'· {connection_label}'
+                    )
+                    streams.append(
+                        StremioStream(
+                            name=name,
+                            description=description_template.format(
+                                filename=filename,
+                                quality=quality_description,
+                                languages=languages,
+                            ),
+                            url=direct_play_url,
+                            subtitles=_external_subtitles(
+                                subtitle_streams,
+                                stream_base,
+                                configuration.access_token,
+                            ),
+                            behaviorHints={
+                                'bingeGroup': quality_description,
+                                'filename': filename,
+                                'videoSize': video_size,
+                            },
+                        ),
+                    )
 
             transcode_url = (
                 configuration.streaming_url
@@ -288,7 +318,11 @@ class PlexMediaMeta(BaseModel):
                             languages=languages,
                         ),
                         url=str(transcode_url % {'videoQuality': 100}),
-                        subtitles=external_subtitles,
+                        subtitles=_external_subtitles(
+                            subtitle_streams,
+                            configuration.streaming_url,
+                            configuration.access_token,
+                        ),
                         behaviorHints={
                             'bingeGroup': quality_description,
                             'filename': filename,
@@ -312,7 +346,11 @@ class PlexMediaMeta(BaseModel):
                                 languages=languages,
                             ),
                             url=str(transcode_url % quality_params['plex_args']),
-                            subtitles=external_subtitles,
+                            subtitles=_external_subtitles(
+                                subtitle_streams,
+                                configuration.streaming_url,
+                                configuration.access_token,
+                            ),
                             behaviorHints={
                                 'bingeGroup': quality_description,
                                 'filename': filename,

--- a/plexio/plex/playback.py
+++ b/plexio/plex/playback.py
@@ -100,6 +100,43 @@ def _position_ms(*, total, start, duration_ms, started_at, now):
     return min(int(initial + elapsed), duration_ms)
 
 
+async def _open_playback_response(
+    *,
+    requester,
+    connections,
+    part_key,
+    access_token,
+    headers,
+):
+    for connection_index, (stream_base, _kind) in enumerate(connections):
+        upstream = stream_base / part_key[1:] % {'X-Plex-Token': access_token}
+        has_fallback = connection_index < len(connections) - 1
+        try:
+            response = await requester(
+                upstream,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(
+                    total=None,
+                    sock_connect=15,
+                    sock_read=60,
+                ),
+            )
+        except (aiohttp.ClientError, TimeoutError):
+            if has_fallback:
+                logger.warning('Plex playback connection failed; trying fallback')
+                continue
+            raise
+        if response.status not in {502, 503, 504} or not has_fallback:
+            return response
+        await response.read()
+        response.close()
+        logger.warning(
+            'Plex playback returned HTTP %s; trying fallback',
+            response.status,
+        )
+    raise RuntimeError('No Plex playback connection was available')
+
+
 async def proxy_playback(
     request,
     *,
@@ -110,11 +147,6 @@ async def proxy_playback(
     part_key,
     identifier,
 ):
-    upstream = (
-        configuration.streaming_url
-        / part_key[1:]
-        % {'X-Plex-Token': configuration.access_token}
-    )
     fwd = {}
     rng = request.headers.get('range')
     if rng:
@@ -122,10 +154,15 @@ async def proxy_playback(
 
     method = request.method.upper()
     requester = client.head if method == 'HEAD' else client.get
-    resp = await requester(
-        upstream,
+    configured_connections = getattr(configuration, 'direct_play_connections', None)
+    if configured_connections is None:
+        configured_connections = [(configuration.streaming_url, None)]
+    resp = await _open_playback_response(
+        requester=requester,
+        connections=configured_connections,
+        part_key=part_key,
+        access_token=configuration.access_token,
         headers=fwd,
-        timeout=aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=60),
     )
     total, start = _total_and_start(resp)
     passthrough = {

--- a/plexio/routers/configuration.py
+++ b/plexio/routers/configuration.py
@@ -159,6 +159,11 @@ async def create_session(
             detail='Sessions are not enabled',
         )
     resources = await fetch_plex_resources(http, account_token, client_identifier)
+    configured_urls = [
+        config.discovery_url,
+        config.streaming_url,
+        *(connection.url for connection in config.streaming_connections),
+    ]
     urls_authorized = all(
         is_authorized_connection(
             resources,
@@ -166,7 +171,7 @@ async def create_session(
             url=url,
             server_token=config.access_token,
         )
-        for url in (config.discovery_url, config.streaming_url)
+        for url in configured_urls
     )
     if not urls_authorized:
         raise HTTPException(

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -64,6 +64,16 @@ class FakeClient:
         return self.stream_response
 
 
+class FallbackClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def head(self, url, **kwargs):
+        self.calls.append(('HEAD', url, kwargs))
+        return self.responses.pop(0)
+
+
 class PlaybackPositionTests(TestCase):
     def test_position_uses_range_offset_and_elapsed_time(self):
         self.assertEqual(
@@ -91,6 +101,46 @@ class PlaybackPositionTests(TestCase):
 
 
 class PlaybackProxyTests(IsolatedAsyncioTestCase):
+    async def test_head_probe_retries_gateway_error_on_alternate_connection(self):
+        failed = FakeResponse(status=503)
+        succeeded = FakeResponse(
+            status=206,
+            headers={
+                'Content-Length': '1000',
+                'Content-Range': 'bytes 0-999/1000',
+                'Content-Type': 'video/x-matroska',
+            },
+        )
+        client = FallbackClient([failed, succeeded])
+        request = SimpleNamespace(method='HEAD', headers={})
+        configuration = SimpleNamespace(
+            streaming_url=URL('https://primary.example.test'),
+            direct_play_connections=[
+                (URL('https://primary.example.test'), None),
+                (URL('https://relay.example.test'), None),
+            ],
+            discovery_url=URL('https://primary.example.test'),
+            access_token='secret',
+        )
+
+        response = await proxy_playback(
+            request,
+            client=client,
+            configuration=configuration,
+            rating_key='42',
+            duration_ms=60_000,
+            part_key='/library/parts/1/file.mkv',
+            identifier='session-id',
+        )
+
+        self.assertEqual(response.status_code, 206)
+        self.assertTrue(failed.read_called)
+        self.assertTrue(failed.closed)
+        self.assertEqual(
+            [call[1].host for call in client.calls],
+            ['primary.example.test', 'relay.example.test'],
+        )
+
     async def test_timeline_sends_query_and_releases_response(self):
         client = FakeClient(FakeResponse())
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from yarl import URL
 
 from plexio.dependencies import get_addon_configuration
-from plexio.models.addon import AddonConfiguration
+from plexio.models.addon import AddonConfiguration, PlexConnectionKind
 from plexio.plex.media_server_api import check_server_connection
 from plexio.plex.plex_tv import is_authorized_connection
 from plexio.rate_limit import InMemoryRateLimiter
@@ -56,6 +56,33 @@ class ConfigurationValidationTests(TestCase):
                 )
         with self.assertRaises(ValidationError):
             AddonConfiguration(**configuration_dict(unexpected='value'))
+
+    def test_direct_play_connections_are_ordered_and_deduplicated(self):
+        model = AddonConfiguration(
+            **configuration_dict(
+                streamingUrl='https://primary.plex.direct:32400',
+                streamingConnectionKind='remote',
+                includeConnectionFallbacks=True,
+                streamingConnections=[
+                    {
+                        'url': 'https://primary.plex.direct:32400/',
+                        'kind': 'remote',
+                    },
+                    {
+                        'url': 'https://relay.plex.direct:443',
+                        'kind': 'relay',
+                    },
+                ],
+            )
+        )
+
+        self.assertEqual(
+            model.direct_play_connections,
+            [
+                (URL('https://primary.plex.direct:32400'), PlexConnectionKind.remote),
+                (URL('https://relay.plex.direct'), PlexConnectionKind.relay),
+            ],
+        )
 
 
 class LegacyConfigurationTests(IsolatedAsyncioTestCase):

--- a/tests/test_stream_options.py
+++ b/tests/test_stream_options.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from unittest import TestCase
+
+from yarl import URL
+
+from plexio.models.addon import PlexConnectionKind
+from plexio.models.plex import PlexMediaMeta
+
+
+def media():
+    return PlexMediaMeta(
+        guid='local://movie/1',
+        type='movie',
+        title='Example',
+        ratingKey='1',
+        key='/library/metadata/1',
+        librarySectionTitle='Movies',
+        Media=[
+            {
+                'videoResolution': '1080',
+                'width': 1920,
+                'Part': [
+                    {
+                        'file': '/media/Example.mkv',
+                        'key': '/library/parts/1/file.mkv',
+                        'size': 1234,
+                        'Stream': [],
+                    }
+                ],
+            }
+        ],
+    )
+
+
+def configuration(**overrides):
+    values = {
+        'server_name': 'Home',
+        'streaming_url': URL('https://primary.plex.direct:32400'),
+        'direct_play_connections': [
+            (URL('https://primary.plex.direct:32400'), PlexConnectionKind.remote),
+            (URL('https://relay.plex.direct'), PlexConnectionKind.relay),
+        ],
+        'access_token': 'secret',
+        'include_direct_play': True,
+        'include_transcode_original': False,
+        'include_transcode_down': False,
+        'transcode_down_qualities': [],
+        'include_plex_tv': False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class StreamOptionTests(TestCase):
+    def test_can_disable_direct_play(self):
+        streams = media().get_stremio_streams(configuration(include_direct_play=False))
+        self.assertEqual(streams, [])
+
+    def test_alternate_connections_are_labelled(self):
+        streams = media().get_stremio_streams(configuration())
+
+        self.assertEqual(len(streams), 2)
+        self.assertIn('Primary Remote', streams[0].description)
+        self.assertIn('Alternate Relay', streams[1].description)
+        self.assertEqual(URL(streams[0].url).host, 'primary.plex.direct')
+        self.assertEqual(URL(streams[1].url).host, 'relay.plex.direct')
+
+    def test_playback_proxy_emits_one_automatic_fallback_stream(self):
+        streams = media().get_stremio_streams(
+            configuration(),
+            play_prefix='https://plexio.example.test/session/play',
+        )
+
+        self.assertEqual(len(streams), 1)
+        self.assertIn('Automatic connection fallback', streams[0].description)


### PR DESCRIPTION
## Summary
- add a configure-page switch to disable Direct Play and use Plex transcodes only
- expose authorized local, remote, and Relay connections as labelled Direct Play choices
- retry alternate connections for playback-reporting streams after network errors or HTTP 502/503/504
- validate all stored fallback origins against the signed-in Plex account

## Verification
- `.venv/bin/ruff check .`
- `.venv/bin/python -m unittest discover -s tests -v` (41 tests)
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high`

Fixes #5