### PR TITLE
Add opt-in Plex collection catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Stream descriptions now normalize source resolution, video/audio codecs,
   Dolby Vision and HDR variants, audio channels, bitrate, languages, subtitles,
   and human-readable file size while retaining Stremio filename/size hints.
+- Added opt-in discovery and individual selection of Plex movie/show
+  collections as stable, paginated Stremio catalogs.
 
 ## v0.8.2
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Plexio is independent and is not affiliated with Plex or Stremio.
 - Local, remote, shared-server, and Plex Relay connections.
 - Clearly labelled alternate-connection streams, with automatic proxy fallback.
 - Continue Watching, Recently Added, searchable library, and sort catalogs.
+- Opt-in, individually selected Plex collection catalogs.
 - IMDb IDs when available, with Plex-native IDs for personal or unmatched media.
 - Stremio stream metadata including resolution, codecs, HDR format, audio
   channels, bitrate, languages, filename, and file size.
@@ -102,6 +103,14 @@ access token from a Plex server you own. Plexio does not bypass Plex remote-play
 rules; depending on Plex policy, remote personal-video playback may require Plex
 Pass or Remote Watch Pass. Never post access tokens in issues or logs.
 
+## Plex collections
+
+Collection discovery is disabled by default, including for existing installs.
+Select one or more movie/show libraries, enable “Include Plex collection
+catalogs”, and choose the collections you want as separate Stremio rows. Each
+row is paginated and tied to its original library; collection renames do not
+change its catalog ID.
+
 ## Health checks
 
 - `GET /api/v1/health` checks Plexio and its session store.
@@ -132,6 +141,7 @@ Use [GitHub Issues](https://github.com/natedogg058/plexio/issues) for support an
 feature requests. Include sanitized logs and diagnostics, but never a Plex token
 or a complete media URL.
 
-Current roadmap themes are richer stream metadata and Plex collection catalogs.
+Current and future work is tracked in the repository's GitHub issues and
+milestones.
 
 See [CHANGELOG.md](CHANGELOG.md) for maintained-fork release history.

--- a/frontend/src/components/configurationForm/fields/collections.tsx
+++ b/frontend/src/components/configurationForm/fields/collections.tsx
@@ -1,0 +1,110 @@
+import { FC } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { ConfigurationFormType } from '@/components/configurationForm/formSchema.tsx';
+import { Checkbox } from '@/components/ui/checkbox.tsx';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form.tsx';
+import { Switch } from '@/components/ui/switch.tsx';
+import { PlexCollection } from '@/types/plex.tsx';
+
+interface Props {
+  form: UseFormReturn<ConfigurationFormType>;
+  collections: PlexCollection[];
+  loading: boolean;
+}
+
+export const CollectionsField: FC<Props> = ({
+  form,
+  collections,
+  loading,
+}) => {
+  const enabled = form.watch('includeCollections');
+  const selectedSections = form.watch('sections');
+
+  return (
+    <FormItem className="rounded-lg border p-2">
+      <FormField
+        control={form.control}
+        name="includeCollections"
+        render={({ field }) => (
+          <div className="items-center justify-between flex flex-row">
+            <div className="space-y-0.5">
+              <FormLabel className="text-base">
+                Include Plex collection catalogs
+              </FormLabel>
+              <FormDescription>
+                Discover collections only when enabled, then choose which ones
+                become separate Stremio rows.
+              </FormDescription>
+            </div>
+            <FormControl>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </FormControl>
+          </div>
+        )}
+      />
+
+      {enabled && (
+        <div className="mt-3 space-y-2 border-t pt-3">
+          {selectedSections.length === 0 ? (
+            <FormDescription>Select at least one library first.</FormDescription>
+          ) : loading ? (
+            <FormDescription>Loading collections from Plex…</FormDescription>
+          ) : collections.length === 0 ? (
+            <FormDescription>
+              No collections were found in the selected libraries.
+            </FormDescription>
+          ) : (
+            collections.map((collection) => (
+              <FormField
+                key={`${collection.sectionKey}-${collection.ratingKey}`}
+                control={form.control}
+                name="collections"
+                render={({ field }) => {
+                  const selected = {
+                    ratingKey: collection.ratingKey,
+                    sectionKey: collection.sectionKey,
+                    title: collection.title,
+                    type: collection.type,
+                  };
+                  return (
+                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value.some(
+                            (item) =>
+                              item.ratingKey === collection.ratingKey &&
+                              item.sectionKey === collection.sectionKey,
+                          )}
+                          onCheckedChange={(checked) =>
+                            checked
+                              ? field.onChange([...field.value, selected])
+                              : field.onChange(
+                                  field.value.filter(
+                                    (item) =>
+                                      item.ratingKey !== collection.ratingKey ||
+                                      item.sectionKey !== collection.sectionKey,
+                                  ),
+                                )
+                          }
+                        />
+                      </FormControl>
+                      <FormLabel className="font-normal">
+                        {collection.title} — {collection.sectionTitle}
+                      </FormLabel>
+                    </FormItem>
+                  );
+                }}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </FormItem>
+  );
+};

--- a/frontend/src/components/configurationForm/fields/index.tsx
+++ b/frontend/src/components/configurationForm/fields/index.tsx
@@ -2,6 +2,7 @@ export { ServerNameField } from './serverName.tsx';
 export { DiscoveryUrlField } from './discoveryUrl.tsx';
 export { StreamingUrlField } from './streamingUrl.tsx';
 export { SectionsField } from './sections.tsx';
+export { CollectionsField } from './collections.tsx';
 export { IncludeDirectPlayField } from './includeDirectPlay.tsx';
 export { IncludeConnectionFallbacksField } from './includeConnectionFallbacks.tsx';
 export { IncludeTranscodeOriginalField } from './includeTranscodeOriginal.tsx';

--- a/frontend/src/components/configurationForm/fields/serverName.tsx
+++ b/frontend/src/components/configurationForm/fields/serverName.tsx
@@ -37,6 +37,8 @@ export const ServerNameField: FC<Props> = ({ form, servers }) => {
               form.resetField('discoveryUrl', { defaultValue: '' });
               form.resetField('streamingUrl', { defaultValue: '' });
               form.resetField('sections', { defaultValue: [] });
+              form.resetField('includeCollections', { defaultValue: false });
+              form.resetField('collections', { defaultValue: [] });
               field.onChange(s);
             }}
             defaultValue={field.value}

--- a/frontend/src/components/configurationForm/formSchema.tsx
+++ b/frontend/src/components/configurationForm/formSchema.tsx
@@ -9,9 +9,20 @@ export const formSchema = z.object({
       z.object({
         key: z.string().min(1).max(128),
         title: z.string().min(1).max(255),
-        type: z.string(),
+        type: z.enum(['movie', 'show']),
       }),
     ),
+  includeCollections: z.boolean(),
+  collections: z
+    .array(
+      z.object({
+        ratingKey: z.string().regex(/^[0-9]+$/),
+        sectionKey: z.string().regex(/^[A-Za-z0-9._-]+$/).max(128),
+        title: z.string().min(1).max(255),
+        type: z.enum(['movie', 'show']),
+      }),
+    )
+    .max(200),
   includeDirectPlay: z.boolean(),
   includeConnectionFallbacks: z.boolean(),
   includeTranscodeOriginal: z.boolean(),

--- a/frontend/src/components/configurationForm/index.tsx
+++ b/frontend/src/components/configurationForm/index.tsx
@@ -14,6 +14,7 @@ import {
   IncludeTranscodeDownFields,
   IncludePlexTvField,
   ReportPlaybackField,
+  CollectionsField,
 } from '@/components/configurationForm/fields';
 import {
   formSchema,
@@ -23,6 +24,7 @@ import { Icons } from '@/components/icons';
 import { Button } from '@/components/ui/button.tsx';
 import { Form } from '@/components/ui/form';
 import usePMSSections from '@/hooks/usePMSSections.tsx';
+import usePMSCollections from '@/hooks/usePMSCollections.tsx';
 import { createSession, getPublicConfig } from '@/services/BackendService.tsx';
 import { PlexServer } from '@/types/plex.tsx';
 
@@ -59,6 +61,8 @@ const ConfigurationForm: FC<Props> = ({
       includePlexTv: false,
       reportPlayback: false,
       sections: [],
+      includeCollections: false,
+      collections: [],
     },
   });
 
@@ -67,6 +71,14 @@ const ConfigurationForm: FC<Props> = ({
 
   const discoveryUrl = form.watch('discoveryUrl');
   const sections = usePMSSections(discoveryUrl, server?.accessToken ?? null);
+  const selectedSections = form.watch('sections');
+  const includeCollections = form.watch('includeCollections');
+  const { collections, loading: collectionsLoading } = usePMSCollections(
+    discoveryUrl,
+    server?.accessToken ?? null,
+    selectedSections,
+    includeCollections,
+  );
 
   const onSubmit: SubmitHandler<ConfigurationFormType> = async (
     configuration,
@@ -85,6 +97,14 @@ const ConfigurationForm: FC<Props> = ({
     const includeConnectionFallbacks =
       configuration.includeDirectPlay &&
       configuration.includeConnectionFallbacks;
+    const configuredSectionKeys = new Set(
+      configuration.sections.map((section) => section.key),
+    );
+    const availableCollectionIds = new Set(
+      collections.map(
+        (collection) => `${collection.sectionKey}:${collection.ratingKey}`,
+      ),
+    );
 
     const normalizedConfiguration = {
       ...configuration,
@@ -108,6 +128,15 @@ const ConfigurationForm: FC<Props> = ({
                   ? 'local'
                   : 'remote',
             }))
+        : [],
+      collections: configuration.includeCollections
+        ? configuration.collections.filter(
+            (collection) =>
+              configuredSectionKeys.has(collection.sectionKey) &&
+              availableCollectionIds.has(
+                `${collection.sectionKey}:${collection.ratingKey}`,
+              ),
+          )
         : [],
       sections: configuration.sections.filter((item) =>
         sections.some((section) => section.key === item.key),
@@ -175,7 +204,14 @@ const ConfigurationForm: FC<Props> = ({
           </>
         )}
         {discoveryUrl && (
-          <SectionsField form={form} sections={sections}></SectionsField>
+          <>
+            <SectionsField form={form} sections={sections}></SectionsField>
+            <CollectionsField
+              form={form}
+              collections={collections}
+              loading={collectionsLoading}
+            />
+          </>
         )}
         <IncludeDirectPlayField form={form} />
         {form.watch('includeDirectPlay') && (

--- a/frontend/src/hooks/usePMSCollections.tsx
+++ b/frontend/src/hooks/usePMSCollections.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { PlexToken } from '@/hooks/usePlexToken.tsx';
+import { getCollections } from '@/services/PMSService.tsx';
+import { PlexCollection, PlexSection } from '@/types/plex.tsx';
+
+const usePMSCollections = (
+  serverUrl: string,
+  plexToken: PlexToken,
+  sections: PlexSection[],
+  enabled: boolean,
+) => {
+  const [collections, setCollections] = useState<PlexCollection[]>([]);
+  const [loading, setLoading] = useState(false);
+  const sectionSignature = sections
+    .map((section) => `${section.key}:${section.type}`)
+    .sort()
+    .join(',');
+
+  useEffect(() => {
+    let active = true;
+    setCollections([]);
+    if (!enabled || !plexToken || !serverUrl || sections.length === 0) {
+      setLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    setLoading(true);
+    void getCollections(serverUrl, plexToken, sections)
+      .then((items) => {
+        if (active) {
+          setCollections(items);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('Error fetching Plex collections:', error);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+    // sectionSignature deliberately captures section identity without making
+    // this effect depend on a newly allocated array each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, plexToken, sectionSignature, serverUrl]);
+
+  return { collections, loading };
+};
+
+export default usePMSCollections;

--- a/frontend/src/services/PMSService.tsx
+++ b/frontend/src/services/PMSService.tsx
@@ -1,9 +1,20 @@
 import axios from 'axios';
-import { PlexSection } from '@/types/plex.tsx';
+import { PlexCollection, PlexSection } from '@/types/plex.tsx';
 
 interface SectionsResponse {
   MediaContainer?: {
     Directory?: PlexSection[];
+  };
+}
+
+interface RawCollection {
+  ratingKey?: string | number;
+  title?: string;
+}
+
+interface CollectionsResponse {
+  MediaContainer?: {
+    Metadata?: RawCollection[];
   };
 }
 
@@ -50,4 +61,48 @@ export const getSections = async (
     console.error('Error fetching Plex servers:', error);
     throw error;
   }
+};
+
+export const getCollections = async (
+  serverUrl: string,
+  token: string,
+  sections: PlexSection[],
+): Promise<PlexCollection[]> => {
+  const responses = await Promise.all(
+    sections.map(async (section) => {
+      try {
+        const response = await axios.get<CollectionsResponse>(
+          `${serverUrl}/library/sections/${encodeURIComponent(section.key)}/collections`,
+          {
+            timeout: 25000,
+            headers: {
+              'X-Plex-Token': token,
+            },
+          },
+        );
+        const collections = response.data.MediaContainer?.Metadata ?? [];
+        return collections.flatMap((collection) =>
+          collection.ratingKey && collection.title
+            ? [
+                {
+                  ratingKey: String(collection.ratingKey),
+                  sectionKey: section.key,
+                  sectionTitle: section.title,
+                  title: collection.title,
+                  type: section.type,
+                },
+              ]
+            : [],
+        );
+      } catch (error) {
+        console.error(`Error fetching collections for ${section.title}:`, error);
+        return [];
+      }
+    }),
+  );
+  return responses.flat().sort(
+    (a, b) =>
+      a.sectionTitle.localeCompare(b.sectionTitle) ||
+      a.title.localeCompare(b.title),
+  );
 };

--- a/frontend/src/types/plex.tsx
+++ b/frontend/src/types/plex.tsx
@@ -33,3 +33,11 @@ export interface PlexSection {
   title: string;
   type: 'movie' | 'show';
 }
+
+export interface PlexCollection {
+  ratingKey: string;
+  sectionKey: string;
+  sectionTitle: string;
+  title: string;
+  type: 'movie' | 'show';
+}

--- a/plexio/models/addon.py
+++ b/plexio/models/addon.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from yarl import URL
 
-from plexio.models.plex import PlexLibrarySection, Resolution
+from plexio.models.plex import PlexLibrarySection, PlexMediaType, Resolution
 from plexio.models.utils import to_camel
 
 
@@ -48,6 +48,23 @@ class PlexStreamingConnection(BaseModel):
         return validate_plex_url(value)
 
 
+class PlexCollectionCatalog(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra='forbid',
+        populate_by_name=True,
+    )
+
+    rating_key: str = Field(pattern=r'^[0-9]+$')
+    section_key: str = Field(pattern=r'^[A-Za-z0-9._-]+$', max_length=128)
+    title: str = Field(min_length=1, max_length=255)
+    type: PlexMediaType
+
+    @property
+    def catalog_id(self) -> str:
+        return f'plexio-collection-{self.section_key}-{self.rating_key}'
+
+
 class AddonConfiguration(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
@@ -67,6 +84,11 @@ class AddonConfiguration(BaseModel):
     server_name: str = Field(min_length=1, max_length=255)
     version: str = Field(default='0.0.1', min_length=1, max_length=64)
     sections: list[PlexLibrarySection] = Field(default_factory=list, max_length=100)
+    include_collections: bool = False
+    collections: list[PlexCollectionCatalog] = Field(
+        default_factory=list,
+        max_length=200,
+    )
     include_direct_play: bool = True
     include_connection_fallbacks: bool = False
     include_transcode_original: bool = False
@@ -79,6 +101,18 @@ class AddonConfiguration(BaseModel):
     @classmethod
     def validate_plex_url(cls, value):
         return validate_plex_url(value)
+
+    @model_validator(mode='after')
+    def validate_collections(self):
+        section_types = {section.key: section.type for section in self.sections}
+        seen = set()
+        for collection in self.collections:
+            if section_types.get(collection.section_key) != collection.type:
+                raise ValueError('Collection must belong to a configured section')
+            if collection.catalog_id in seen:
+                raise ValueError('Collections must be unique')
+            seen.add(collection.catalog_id)
+        return self
 
     def to_storage_dict(self) -> dict:
         config = self.model_dump(by_alias=True)
@@ -109,3 +143,7 @@ class AddonConfiguration(BaseModel):
                 seen.add(key)
                 deduplicated.append((URL(key), kind))
         return deduplicated
+
+    @property
+    def configured_collections(self) -> list[PlexCollectionCatalog]:
+        return self.collections if self.include_collections else []

--- a/plexio/plex/media_server_api.py
+++ b/plexio/plex/media_server_api.py
@@ -95,6 +95,38 @@ async def get_section_media(
     return [PlexMediaMeta(**meta) for meta in metadata]
 
 
+async def get_collection_media(
+    *,
+    client: ClientSession,
+    url: URL,
+    token: str,
+    rating_key: str,
+    skip: int,
+) -> list[PlexMediaMeta]:
+    json = await get_json(
+        client=client,
+        url=url / 'library/collections' / rating_key / 'items',
+        params={
+            'includeGuids': 1,
+            'X-Plex-Container-Start': skip,
+            'X-Plex-Container-Size': 100,
+            'X-Plex-Token': token,
+        },
+    )
+    metadata = json['MediaContainer'].get('Metadata', [])
+    media = []
+    seen = set()
+    for item in metadata:
+        if item.get('type') not in {'movie', 'show'}:
+            continue
+        identity = str(item.get('ratingKey') or item.get('guid') or '')
+        if not identity or identity in seen:
+            continue
+        seen.add(identity)
+        media.append(PlexMediaMeta(**item))
+    return media
+
+
 async def get_on_deck(
     *,
     client: ClientSession,

--- a/plexio/routers/addon.py
+++ b/plexio/routers/addon.py
@@ -32,6 +32,7 @@ from plexio.models.utils import (
 from plexio.plex.media_server_api import (
     SORT_OPTIONS,
     get_all_episodes,
+    get_collection_media,
     get_media,
     get_media_by_rating_key,
     get_on_deck,
@@ -244,6 +245,20 @@ async def get_manifest(
                     ],
                 ),
             )
+        for collection in configuration.configured_collections:
+            section_title = next(
+                section.title
+                for section in configuration.sections
+                if section.key == collection.section_key
+            )
+            catalogs.append(
+                StremioCatalogManifest(
+                    id=collection.catalog_id,
+                    type=PLEX_TO_STREMIO_MEDIA_TYPE[collection.type],
+                    name=f'Collection: {collection.title} ({section_title}) | {sv}',
+                    extra=[{'name': 'skip', 'isRequired': False}],
+                ),
+            )
 
         name += f' ({configuration.server_name})'
         description += f' Your installation ID: {installation_id or session_id}'
@@ -295,8 +310,15 @@ async def get_catalog(
     catalog_id: str,
     extra: str = '',
 ) -> StremioCatalog:
-    extras = dict(e.split('=') for e in extra.split('&') if e)
-    skip = extras.get('skip', 0)
+    extras = {}
+    for value in extra.split('&'):
+        key, separator, item = value.partition('=')
+        if separator:
+            extras[key] = item
+    try:
+        skip = max(int(extras.get('skip', 0)), 0)
+    except (TypeError, ValueError):
+        skip = 0
     if catalog_id == 'plexio-ondeck':
         items = await get_on_deck(
             client=http,
@@ -306,6 +328,26 @@ async def get_catalog(
         metas = await _map_on_deck(http, items, configuration, stremio_type)
     elif catalog_id == 'plexio-recent':
         metas = await _recently_added(http, configuration, stremio_type, skip)
+    elif catalog_id.startswith('plexio-collection-'):
+        collection = next(
+            (
+                item
+                for item in configuration.configured_collections
+                if item.catalog_id == catalog_id
+                and PLEX_TO_STREMIO_MEDIA_TYPE[item.type] == stremio_type
+            ),
+            None,
+        )
+        if collection is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+        media = await get_collection_media(
+            client=http,
+            url=configuration.discovery_url,
+            token=configuration.access_token,
+            rating_key=collection.rating_key,
+            skip=skip,
+        )
+        metas = [item.to_stremio_meta_review(configuration) for item in media]
     else:
         media = await get_section_media(
             client=http,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,190 @@
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+from yarl import URL
+
+from plexio.models.addon import AddonConfiguration
+from plexio.models.plex import PlexMediaMeta
+from plexio.models.stremio import StremioMediaType
+from plexio.plex.media_server_api import get_collection_media
+from plexio.routers.addon import get_catalog, get_manifest
+
+
+def configuration_dict(**overrides):
+    values = {
+        'accessToken': 'secret',
+        'discoveryUrl': 'https://plex.example.test',
+        'streamingUrl': 'https://plex.example.test',
+        'serverName': 'Home',
+        'sections': [{'key': '1', 'title': 'Movies', 'type': 'movie'}],
+        'includeCollections': True,
+        'collections': [
+            {
+                'ratingKey': '42',
+                'sectionKey': '1',
+                'title': 'Favourites',
+                'type': 'movie',
+            }
+        ],
+    }
+    values.update(overrides)
+    return values
+
+
+def movie(rating_key='7'):
+    return PlexMediaMeta(
+        guid=f'local://movie/{rating_key}',
+        ratingKey=rating_key,
+        type='movie',
+        title='Example movie',
+    )
+
+
+class CollectionConfigurationTests(IsolatedAsyncioTestCase):
+    async def test_manifest_only_includes_opted_in_collections_with_stable_ids(self):
+        enabled = AddonConfiguration(**configuration_dict())
+        disabled = AddonConfiguration(
+            **configuration_dict(includeCollections=False),
+        )
+
+        enabled_manifest = await get_manifest(enabled, session_id='session')
+        disabled_manifest = await get_manifest(disabled, session_id='session')
+
+        collection = next(
+            catalog
+            for catalog in enabled_manifest.catalogs
+            if catalog.id.startswith('plexio-collection-')
+        )
+        self.assertEqual(collection.id, 'plexio-collection-1-42')
+        self.assertEqual(collection.type, StremioMediaType.movie)
+        self.assertEqual(collection.name, 'Collection: Favourites (Movies) | Home')
+        self.assertEqual(collection.extra, [{'name': 'skip', 'isRequired': False}])
+        self.assertFalse(
+            any(
+                catalog.id.startswith('plexio-collection-')
+                for catalog in disabled_manifest.catalogs
+            )
+        )
+
+    async def test_collection_must_match_a_configured_section_and_be_unique(self):
+        invalid_collections = (
+            [
+                {
+                    'ratingKey': '42',
+                    'sectionKey': '2',
+                    'title': 'Wrong section',
+                    'type': 'movie',
+                }
+            ],
+            [
+                {
+                    'ratingKey': '42',
+                    'sectionKey': '1',
+                    'title': 'Wrong type',
+                    'type': 'show',
+                }
+            ],
+            configuration_dict()['collections'] * 2,
+        )
+        for collections in invalid_collections:
+            with (
+                self.subTest(collections=collections),
+                self.assertRaises(ValidationError),
+            ):
+                AddonConfiguration(
+                    **configuration_dict(collections=collections),
+                )
+
+
+class CollectionCatalogTests(IsolatedAsyncioTestCase):
+    @patch('plexio.routers.addon.get_collection_media', new_callable=AsyncMock)
+    async def test_catalog_fetches_configured_collection_page(self, fetch):
+        fetch.return_value = [movie()]
+        configuration = AddonConfiguration(**configuration_dict())
+        http = SimpleNamespace()
+
+        catalog = await get_catalog(
+            http=http,
+            configuration=configuration,
+            stremio_type=StremioMediaType.movie,
+            catalog_id='plexio-collection-1-42',
+            extra='skip=20',
+        )
+
+        self.assertEqual([item.name for item in catalog.metas], ['Example movie'])
+        fetch.assert_awaited_once_with(
+            client=http,
+            url=URL('https://plex.example.test'),
+            token='secret',
+            rating_key='42',
+            skip=20,
+        )
+
+    async def test_catalog_rejects_unconfigured_or_wrong_type_collection(self):
+        configuration = AddonConfiguration(**configuration_dict())
+        for catalog_id, media_type in (
+            ('plexio-collection-1-999', StremioMediaType.movie),
+            ('plexio-collection-1-42', StremioMediaType.series),
+        ):
+            with self.subTest(catalog_id=catalog_id, media_type=media_type):
+                with self.assertRaises(HTTPException) as raised:
+                    await get_catalog(
+                        http=SimpleNamespace(),
+                        configuration=configuration,
+                        stremio_type=media_type,
+                        catalog_id=catalog_id,
+                    )
+                self.assertEqual(raised.exception.status_code, 404)
+
+
+class CollectionMediaTests(IsolatedAsyncioTestCase):
+    @patch('plexio.plex.media_server_api.get_json', new_callable=AsyncMock)
+    async def test_collection_media_is_paginated_top_level_and_deduplicated(
+        self,
+        fetch,
+    ):
+        item = {
+            'guid': 'local://movie/7',
+            'ratingKey': '7',
+            'type': 'movie',
+            'title': 'Example movie',
+        }
+        fetch.return_value = {
+            'MediaContainer': {
+                'Metadata': [
+                    item,
+                    dict(item),
+                    {
+                        'guid': 'local://episode/8',
+                        'ratingKey': '8',
+                        'type': 'episode',
+                        'title': 'Loose episode',
+                    },
+                ]
+            }
+        }
+
+        media = await get_collection_media(
+            client=SimpleNamespace(),
+            url=URL('https://plex.example.test'),
+            token='secret',
+            rating_key='42',
+            skip=100,
+        )
+
+        self.assertEqual([item.rating_key for item in media], ['7'])
+        self.assertEqual(
+            fetch.await_args.kwargs['url'].path,
+            '/library/collections/42/items',
+        )
+        self.assertEqual(
+            fetch.await_args.kwargs['params']['X-Plex-Container-Start'],
+            100,
+        )
+        self.assertEqual(
+            fetch.await_args.kwargs['params']['X-Plex-Container-Size'],
+            100,
+        )


### PR DESCRIPTION
## Summary
- discover collections only after the configure-page option is enabled
- let users select individual movie/show collections from configured libraries
- emit stable, per-library Stremio catalog IDs and paginated collection rows
- reject unconfigured/type-mismatched catalogs and deduplicate top-level media
- tolerate partial collection-discovery failures without blocking other libraries

## Verification
- `.venv/bin/ruff check .`
- `.venv/bin/python -m unittest discover -s tests -v` (48 tests)
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high`

Fixes #13