### PR TITLE
Handle stalled shared-server playback reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ If you enable “Report playback to Plex”, Direct Play streams pass through
 Plexio. The public URL must then be reachable by every Stremio device and your
 proxy must permit byte-range requests and long-running responses. Plexio sends
 timeline heartbeats independently of media reads, so buffered external players
-remain active in Plex even while they temporarily stop requesting bytes.
+remain active in Plex even while they temporarily stop requesting bytes. When a
+player is actively waiting for data, Plexio ends an upstream response that
+delivers no media for 30 seconds so the player can reconnect instead of hanging
+indefinitely on a stalled shared server.
 
 ## Playback controls
 

--- a/plexio/plex/playback.py
+++ b/plexio/plex/playback.py
@@ -19,6 +19,7 @@ from fastapi.responses import Response, StreamingResponse
 PLEX_PRODUCT = 'Plexio'
 CHUNK = 1 << 16  # 64 KiB
 PING_INTERVAL = 10.0  # seconds between Plex timeline updates
+UPSTREAM_READ_TIMEOUT = 30.0  # seconds waiting for a requested media chunk
 
 logger = logging.getLogger(__name__)
 
@@ -166,12 +167,25 @@ async def _open_playback_response(
         timeout=aiohttp.ClientTimeout(
             total=None,
             sock_connect=15,
-            # Buffered external players can intentionally leave the upstream
-            # response idle for minutes. The downstream connection lifecycle
-            # remains the cancellation boundary.
+            # aiohttp's socket timer keeps running when Plexio is backpressured
+            # by a full downstream player buffer. Keep it disabled here and
+            # time only active media reads in the response iterator instead.
             sock_read=None,
         ),
     )
+
+
+async def _read_playback_chunk(resp):
+    """Read one requested upstream chunk without timing downstream idle time."""
+    try:
+        async with asyncio.timeout(UPSTREAM_READ_TIMEOUT):
+            return await resp.content.read(CHUNK)
+    except TimeoutError:
+        logger.warning(
+            'Plex playback upstream produced no media for %.0f seconds',
+            UPSTREAM_READ_TIMEOUT,
+        )
+        raise
 
 
 async def proxy_playback(
@@ -230,7 +244,7 @@ async def proxy_playback(
         heartbeat = None
         heartbeat_stopped = asyncio.Event()
         try:
-            async for chunk in resp.content.iter_chunked(CHUNK):
+            while chunk := await _read_playback_chunk(resp):
                 if started_at is None:
                     started_at = monotonic()
                     heartbeat = asyncio.create_task(

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -9,19 +9,30 @@ from plexio.plex.playback import _position_ms, _timeline, proxy_playback
 
 
 class FakeContent:
-    def __init__(self, chunks):
-        self.chunks = chunks
+    def __init__(self, chunks, *, block_after=False):
+        self.chunks = list(chunks)
+        self.block_after = block_after
 
-    async def iter_chunked(self, _size):
-        for chunk in self.chunks:
-            yield chunk
+    async def read(self, _size):
+        if self.chunks:
+            return self.chunks.pop(0)
+        if self.block_after:
+            await asyncio.Event().wait()
+        return b''
 
 
 class FakeResponse:
-    def __init__(self, *, headers=None, status=200, chunks=()):
+    def __init__(
+        self,
+        *,
+        headers=None,
+        status=200,
+        chunks=(),
+        block_after=False,
+    ):
         self.headers = headers or {}
         self.status = status
-        self.content = FakeContent(chunks)
+        self.content = FakeContent(chunks, block_after=block_after)
         self.closed = False
         self.read_called = False
 
@@ -208,6 +219,7 @@ class PlaybackProxyTests(IsolatedAsyncioTestCase):
             ['0', '12000'],
         )
 
+    @patch('plexio.plex.playback.UPSTREAM_READ_TIMEOUT', 0.01)
     @patch('plexio.plex.playback.PING_INTERVAL', 0.01)
     async def test_heartbeat_continues_while_downstream_is_idle(self):
         upstream = FakeResponse(
@@ -245,6 +257,7 @@ class PlaybackProxyTests(IsolatedAsyncioTestCase):
             if '/:/timeline' in str(url)
         ]
         self.assertGreaterEqual(states.count('playing'), 2)
+        self.assertEqual(await anext(iterator), b'second')
 
         await iterator.aclose()
         states = [
@@ -254,6 +267,47 @@ class PlaybackProxyTests(IsolatedAsyncioTestCase):
         ]
         self.assertEqual(states[-1], 'stopped')
         self.assertTrue(upstream.closed)
+
+    @patch('plexio.plex.playback.UPSTREAM_READ_TIMEOUT', 0.01)
+    async def test_active_upstream_stall_times_out_and_closes_response(self):
+        upstream = FakeResponse(
+            headers={
+                'Content-Length': '1000',
+                'Content-Type': 'video/x-matroska',
+            },
+            chunks=(b'first',),
+            block_after=True,
+        )
+        client = FakeClient(upstream)
+        configuration = SimpleNamespace(
+            streaming_url=URL('https://plex.example.test'),
+            discovery_url=URL('https://plex.example.test'),
+            access_token='secret',
+        )
+        request = SimpleNamespace(method='GET', headers={})
+
+        response = await proxy_playback(
+            request,
+            client=client,
+            configuration=configuration,
+            rating_key='42',
+            duration_ms=60_000,
+            part_key='/library/parts/1/file.mkv',
+            identifier='session-id',
+        )
+        iterator = response.body_iterator
+
+        self.assertEqual(await anext(iterator), b'first')
+        with self.assertRaises(TimeoutError):
+            await anext(iterator)
+
+        self.assertTrue(upstream.closed)
+        states = [
+            url.query['state']
+            for _, url, _ in client.calls
+            if '/:/timeline' in str(url)
+        ]
+        self.assertEqual(states, ['playing', 'stopped'])
 
     async def test_head_probe_returns_headers_without_streaming_or_timeline(self):
         upstream = FakeResponse(


### PR DESCRIPTION
## What changed

- bound only active upstream media reads to 30 seconds so a stalled shared Plex server cannot leave players hanging indefinitely
- keep aiohttp's background socket timeout disabled so a full downstream player buffer can remain idle without terminating playback
- preserve independent Plex timeline heartbeats and prompt upstream cleanup
- document the stall behavior and add regressions for both active stalls and intentional downstream idle periods

## Why this differs from the proposed one-line change

Setting `aiohttp.ClientTimeout(sock_read=30)` starts a transport-level timer that continues while Plexio is backpressured by a player with a full buffer. That would regress #19 by terminating valid buffered playback. The new timeout surrounds only `resp.content.read(...)`, so its clock exists only when the downstream player has requested another chunk and Plexio is genuinely waiting on Plex.

## Validation

- 60 backend tests pass
- Ruff lint and format checks pass
- frontend lint and production build pass
- container image builds successfully
- Python and npm dependency audits report no known vulnerabilities

Addresses #24.